### PR TITLE
Feat: perfume조회시 note의 정보도 같이 전달하기 #28

### DIFF
--- a/perfume/serializers.py
+++ b/perfume/serializers.py
@@ -1,9 +1,13 @@
 from rest_framework import serializers
 from .models import Perfume
 from perfume.models import Review
-
+from custom_perfume.serializers import NoteSerializer
 # perfume 
 class PerfumeSerializer(serializers.ModelSerializer):
+    top_notes = NoteSerializer(many=True)
+    heart_notes = NoteSerializer(many=True)
+    base_notes = NoteSerializer(many=True)
+    none_notes = NoteSerializer(many=True)
     class Meta :
         model = Perfume
         fields = "__all__"


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/28-perfumeSerializer -> main

## 변경 사항
1. perfume 조회시 note가 id값으로 출력했는데 note의 정보도 같이 전달
	- perfume.PerfumeSerializer에서 note필드들 custom_perfume.NoteSerializer와 연결


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
![Screenshot 2022-12-07 at 6 35 46 PM](https://user-images.githubusercontent.com/12287842/206142529-88684257-b97b-4b7c-b3ed-7a5abad44e0a.png)
