### PR TITLE
Feat: 커스텀향수 조회 및 삭제 API 구현 #52

### DIFF
--- a/custom_perfume/urls.py
+++ b/custom_perfume/urls.py
@@ -3,5 +3,6 @@ from custom_perfume import views
 
 urlpatterns = [
     path('', views.CustomPerfumeView.as_view(), name='custom_perfume_view'),
-    
+    path('custom/', views.CustomPerfumeCreateView.as_view(), name='custom_perfume_create_view'),
+    path('<int:custom_perfume_id>/', views.CustomPerfumeDeleteView.as_view(), name='custom_perfume_delete_view'),
 ]

--- a/custom_perfume/views.py
+++ b/custom_perfume/views.py
@@ -2,11 +2,18 @@ from django.contrib.auth import get_user_model
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.generics import get_object_or_404
 from .models import *
 from .serializers import *
 
 # Create your views here.
 class CustomPerfumeView(APIView):
+    def get (self, request):
+        custom_perfume = CustomPerfume.objects.all().order_by('-created_at')
+        serializer = CustomPerfumeSerializer(custom_perfume, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+class CustomPerfumeCreateView(APIView):
     def get (self, request):
         notes = Note.objects.all()
         packages = Package.objects.all()
@@ -19,11 +26,22 @@ class CustomPerfumeView(APIView):
         return Response({'notes':notes_serializer.data, 'packages':packages_serializer.data, 'note_category':note_category_serializer.data, 'package_category':package_category_serializer.data}, status=status.HTTP_200_OK)
 
     def post (self, request):
-        # request_user = request.user     # 로그인한 유저
-        request_user = get_user_model().objects.get(id=1)   # 로그인한 유저(임시 1번 유저)
+        request_user = request.user     # 로그인한 유저
+        # request_user = get_user_model().objects.get(id=1)   # 로그인한 유저(임시 1번 유저)
         serializer = CustomPerfumeSerializer(data=request.data)
         request.data.update({'creator': request_user.id})
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+class CustomPerfumeDeleteView(APIView):
+    def delete (self, request, custom_perfume_id):
+        request_user = request.user     # 로그인한 유저
+        # request_user = get_user_model().objects.get(id=1)   # 로그인한 유저(임시 1번 유저)
+        custom_perfume = get_object_or_404(CustomPerfume, id=custom_perfume_id)
+        if request_user == custom_perfume.creator :
+            custom_perfume.delete()
+            return Response({"messages": "커스텀한 향수가 삭제 되었습니다."}, status=status.HTTP_204_NO_CONTENT)
+        return Response("권한이 없습니다!", status=status.HTTP_403_FORBIDDEN)
+            


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/52-custom_perfume_delete -> develop

## 변경 사항
1. 커스텀 향수 조회 및 삭제 API 구현
    - 조회 url ( /custom_perfume/ )
    - 삭제 url ( /custom_perfume/<int:id>/ )

3. url 변경
    - [ ] 커스텀 향수 목록 ( /custom_perfume/ )
    - [ ] 커스텀 향수 향, 용기 목록 ( /custom_perfume/custom/ )
    - [ ] 커스텀 향수 생성 ( /custom_perfume/custom/ )

4. 임시 유저 -> 로그인 유저로 변경


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
![image](https://user-images.githubusercontent.com/113074549/206836639-794fac61-7b87-4406-a4f7-ffd3d4583934.png)

