### PR TITLE
Fix: Perfume 찜순으로 정렬시 중복 오류 수정

### DIFF
--- a/perfume/views.py
+++ b/perfume/views.py
@@ -6,7 +6,7 @@ from .models import Perfume, Review
 from .serializers import PerfumeSerializer,ReviewSerializer,ReviewCreateSerializer,ReviewUpdateSerializer,SurveySerializer
 from django.contrib.auth.decorators import login_required
 from django.contrib.auth import get_user_model
-from django.db.models import Max
+from django.db.models import Max,Count
 from .recommend import recommend
 import random
 from rest_framework.permissions import AllowAny
@@ -15,7 +15,7 @@ from .permission import IsAuthenticated, IsAdminOrReadOnly, IsOwnerIsAdminOrRead
 class PerfumeView(APIView):
     permission_classes = [IsAdminOrReadOnly]
     def get(self, request):
-        all_perfume = Perfume.objects.all().order_by("-likes", "-launch_date","brand","title")[:20]
+        all_perfume = Perfume.objects.annotate(likes_count=Count('likes')).order_by("-likes_count", "-launch_date","brand","title")[:20]
         serializer = PerfumeSerializer(all_perfume, many=True)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
@@ -76,7 +76,7 @@ class PerfumeRecommendView(APIView):
             serializer = PerfumeSerializer(recommend_perfume, many=True)
         else:
             # 추천 내용이 없으면 전체목록 보여주기
-            all_perfume = Perfume.objects.all().order_by("-likes","-launch_date","brand","title")[:limit]
+            all_perfume = Perfume.objects.annotate(likes_count=Count('likes')).order_by("-likes_count", "-launch_date","brand","title")[:limit]
             serializer = PerfumeSerializer(all_perfume, many=True)
            
         return Response(serializer.data, status=status.HTTP_200_OK)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/78-perfumeLikeSort -> develop

## 변경 사항
1. 다른 계정으로 찜 선택시 찜순 정렬에서 중복으로 향수가 나오는 오류 발생 
    - annotate에서 likes_count라는 필드를 만들어서 정렬하면서 해결


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.