### PR TITLE
Feat: 회원가입시 유효성검사 에러메세지 수정 및 Validator추가 #80

### DIFF
--- a/users/serializers.py
+++ b/users/serializers.py
@@ -1,5 +1,6 @@
 from rest_framework import serializers, exceptions
 from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+from rest_framework.validators import UniqueTogetherValidator, UniqueValidator
 
 from users.models import User
 from django.contrib.auth import get_user_model
@@ -24,6 +25,8 @@ from django.conf import settings
 from django.utils.html import strip_tags
 
 class UserSerializer(serializers.ModelSerializer):
+    email = serializers.EmailField(max_length=255, validators=[UniqueValidator(queryset=get_user_model().objects.all(), message="이 이메일은 이미 사용중입니다.")])
+    username = serializers.CharField(max_length=15, validators=[UniqueValidator(queryset=get_user_model().objects.all(), message="이 닉네임은 이미 사용중입니다.")])
     password2 = serializers.CharField(
         style = {'input_type': 'password'},
         write_only = True
@@ -58,9 +61,10 @@ class UserSerializer(serializers.ModelSerializer):
         return user
     
     def validate_phone_number(self, value):
-        is_phone_number_valid = re.match("\d{3}-\d{3,4}-\d{4}", value)
-        if not is_phone_number_valid:
-            raise serializers.ValidationError("전화번호를 확인해 주세요.")
+        if value:
+            is_phone_number_valid = re.match("\d{3}-\d{3,4}-\d{4}", value)
+            if not is_phone_number_valid:
+                raise serializers.ValidationError("전화번호를 확인해 주세요.")
         return value
     
     def validate_password(self, value):
@@ -75,10 +79,10 @@ class UserSerializer(serializers.ModelSerializer):
     
     def validate(self, attrs):
         if not attrs["password"]:
-            raise serializers.ValidationError("비밀번호를 입력해 주세요.")
+            raise serializers.ValidationError({"password":"비밀번호를 입력해 주세요."})
         
         if not attrs["password"] == attrs["password2"]:
-            raise serializers.ValidationError("비밀번호가 일치하지 않습니다.")
+            raise serializers.ValidationError({"password2":"비밀번호가 일치하지 않습니다."})
         return attrs
     
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/80-FixSignupValidateMessage -> develop

Close #80 

## 변경 사항
1. 회원가입시 유효성검사 에러메세지 수정 및 Validator추가했습니다.
2. 필드 조건이 unique인 필드는 Django에서 만들어져있는 메세지를 전달해줌
    - [ ] 이 메세지 커스텀하기 위해 시리얼라이저에 필드 추가했습니다.
3. 전화번호 필드는 null, blank허용 하므로, 요청시 들어온 value가 있을때만 검사하도록 조건문 걸어주었습니다.


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.

### 필드 추가하여 validator 추가
<img width="893" alt="image" src="https://user-images.githubusercontent.com/96516988/207250161-692866a2-7cd9-49dd-836c-5881365e058c.png">
