### PR TITLE
Feat: Perfume 검색/정렬/페이지네이션 구현

### DIFF
--- a/perfume/pagination.py
+++ b/perfume/pagination.py
@@ -3,3 +3,13 @@ from rest_framework.pagination import PageNumberPagination
 class PerfumePagination(PageNumberPagination):
     page_size = 20
     page_size_query_param = 'page_size'
+    page_query_param = 'page'
+
+    def get_paginated_response(self, data):
+        return {
+            'next': self.page.next_page_number() if self.page.has_next() else None,
+            'previous': self.page.previous_page_number() if self.page.has_previous() else None,
+            'last': (self.page.paginator.count//self.page_size)+1,
+            'count': self.page.paginator.count,
+            'results': data
+        }

--- a/perfume/views.py
+++ b/perfume/views.py
@@ -21,6 +21,17 @@ class PerfumeView(GenericAPIView):
       - pagination : 20개씩
       - ?search= : 향수명, 브랜드명, 향이름(영문/한글)
       - ?ordering= : 최신순, 찜많은순, 리뷰평점순, 리뷰많은순
+
+      향수 목록 조회 결과
+      {
+        count: 데이터 갯수
+        last: 마지막 페이지
+        next: 다음 페이지
+        previous: 이전 페이지
+        results:{
+            향수 데이터
+        }
+      }
     '''
     permission_classes = [IsAdminOrReadOnly]
 
@@ -36,7 +47,8 @@ class PerfumeView(GenericAPIView):
         queryset = self.filter_queryset(self.get_queryset())
         page_queryset = self.paginate_queryset(queryset)
         serializer = PerfumeSerializer(page_queryset, many=True)
-        return Response(serializer.data, status=status.HTTP_200_OK)
+        result = self.get_paginated_response(data=serializer.data)
+        return Response(result, status=status.HTTP_200_OK)
 
     def post(self, request):
         serializer = PerfumeSerializer(data=request.data)


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/perfumeFilter -> develop

## 변경 사항
1. 향수 검색기능
- [x] 향수명, 브랜드, 향이름(top/heart/base/none, 영문/한글)에 있는 단어로 검색 가능
- [x] `perfume/?search=` url뒤에 검색어 전달

2. 향수 정렬기능
- [x] 최신순, 찜많은순, 리뷰평점순, 리뷰많은순 으로 향수 목록 정렬
- [x] `perfume/?ordering=` url 뒤에 정렬 기준 전달

3. 향수 페이지네이션 기능
- [x] `perfume/?page=`으로 url뒤에 페이지 전달
- [x] 목록 조회시 페이지네이션 정보도 추가해서 전달: get_paginated_response
	- count: 데이터 갯수
	- last: 마지막 페이지
	- next: 다음페이지
	- previous : 이전페이지
	- results: 향수 serializer.data


## 테스트 결과
#### 전달되는 데이터 
![Screenshot 2022-12-20 at 6 24 58 PM](https://user-images.githubusercontent.com/12287842/208631528-5d4b8f09-7e9b-4617-b180-ccfd50e48a71.png)

#### 검색/정렬/페이지네이션
![Screenshot 2022-12-20 at 6 26 47 PM](https://user-images.githubusercontent.com/12287842/208632039-10fc97cb-fff3-40ee-91c2-cdd1b29e4c4a.png)
![Screenshot 2022-12-20 at 6 26 53 PM](https://user-images.githubusercontent.com/12287842/208632026-b2ba7b00-6cba-4b45-9e4f-c396d757b033.png)
