### PR TITLE
Fix: 기준에 따른 향 데이터 축소 수정 #103

### DIFF
--- a/custom_perfume/views.py
+++ b/custom_perfume/views.py
@@ -5,6 +5,7 @@ from rest_framework import status
 from rest_framework.generics import get_object_or_404
 from .models import *
 from .serializers import *
+from django.db.models import Count
 
 # Create your views here.
 class CustomPerfumeView(APIView):
@@ -21,10 +22,10 @@ class CustomPerfumeCreateView(APIView):
         custom_notes = []
         for note in notes:
             cnt = 0
-            cnt += note.perfumes_top.exists()
-            cnt += note.perfumes_none.exists()
-            cnt += note.perfumes_heart.exists()
-            cnt += note.perfumes_base.exists()
+            cnt += note.perfumes_top.aggregate(cnt=Count('id'))["cnt"]
+            cnt += note.perfumes_none.aggregate(cnt=Count('id'))["cnt"]
+            cnt += note.perfumes_heart.aggregate(cnt=Count('id'))["cnt"]
+            cnt += note.perfumes_base.aggregate(cnt=Count('id'))["cnt"]
             if cnt > 1:
                 custom_notes.append(note)
         packages = Package.objects.all()


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/103-ReduceCustomNotes -> develop
Close #103 
## 변경 사항
1. 축소된 향 데이터 걸러내는 로직 다시 구현했습니다.
    - 기성 향수의 한 노트 카테고리에서도 2회 이상 사용되면, 커스텀 향수 제작시 사용할 수 있습니다.


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.

### 조회시, 걸러낸 향 데이터 갯수 313으로 배포환경에서 구한 갯수와 일치합니다.

<img width="606" alt="스크린샷 2022-12-22 오전 1 09 13" src="https://user-images.githubusercontent.com/96516988/208950745-ab49c454-75a9-4ba2-a66c-27b71100a065.png">