### PR TITLE
Fix: 브랜드 랜덤 출력시 중복 출력되는 부분 해결

### DIFF
--- a/perfume/views.py
+++ b/perfume/views.py
@@ -197,16 +197,9 @@ class BrandRandomView(APIView):
     permission_classes = [AllowAny]
     def get(self, request):
         limit = int(request.data.get("limit",8)) # 데이터 없으면 limit = 8
-
-        max_id = Brand.objects.aggregate(max_id=Max('id'))['max_id']
-        brand_random_list = []
-        while len(brand_random_list) < limit: # 무조건 limit 갯수만큼 random 추출
-            random_index = random.randint(1, max_id)
-            brand = Brand.objects.get(id=random_index)
-            if brand:
-                serializer = AllBrandSerializer(brand)
-                brand_random_list.append(serializer.data)
-        return Response(brand_random_list, status=status.HTTP_200_OK)
+        brand  = Brand.objects.all().order_by("?")[:limit]
+        serializer = AllBrandSerializer(brand, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 # 리뷰 전체


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/BrandRandomFix -> develop

## 변경 사항
1. 브랜드 랜덤 출력시 중복으로 출력되는 오류 해결
    - order_by("?")으로 무작위 정렬후 limit 갯수만큼 자르기


## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.