### PR TITLE
Fix: 배포환경에서 Swagger API의 static 파일 로딩 오류 해결 #131

### DIFF
--- a/mmop/settings.py
+++ b/mmop/settings.py
@@ -153,8 +153,8 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/
-STATIC_ROOT = BASE_DIR / "static"
-STATIC_URL = "/users/static/"
+STATIC_ROOT = os.path.join(BASE_DIR, "static")
+STATIC_URL = "/static/"
 
 # Media files
 # https://docs.djangoproject.com/en/4.1/ref/settings/#std-setting-MEDIA_ROOT


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 디자인 변경
- [ ] 기능 추가
- [ ] 기능 삭제
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
main -> deploy

## 변경 사항
1. DEBUG=True일 때는 Django에 내장된 `django.contrib.staticfiles` 앱에서 자동으로 정적파일 제공해줌
2. 배포 환경에서 admin, swagger페이지 스태틱파일들이 제대로 제공이 안되서 css깨짐
      - DEBUG=False인 환경에서는 Django staticfiles앱이 자동으로 정적파일 제공해주지 않음.
      - 정적파일은 Nginx가 제공해줌 - 배포환경에서 Nginx 사용을 위해 collectstatic 실행한 static폴더 생성되는 것 확인함 
      - 로그 확인 시 Nginx에서 스태틱 파일 요청시, `users/static`에서 파일을 찾음.
      - **해당 부분 STATIC_URL 수정함으로써 해결**

## 테스트 결과
변경 사항을 설명하는데 도움이 되는 스크린샷이나 참고 자료를 추가해주세요.
<img width="1414" alt="image" src="https://user-images.githubusercontent.com/96516988/216867649-4aa60c73-41cd-4add-aad6-0d3bb27b23f2.png">
